### PR TITLE
Create transformation for open cases

### DIFF
--- a/transformations/models/MPAM_due_cases/mpam_due_cases.sql
+++ b/transformations/models/MPAM_due_cases/mpam_due_cases.sql
@@ -9,7 +9,7 @@ WITH mpam_due_cases AS (
            'DIRECTORATE' as "Directorate",
            'SIGNEE' as "Signee",
            stage as "Stage",
-           To_Char(case_deadline, 'Day') as "Day"
+           To_Char(case_deadline, 'fmDay') as "Day"
 
     FROM {{ ref('merged_cases') }} AS c
 

--- a/transformations/models/open_cases/models.yml
+++ b/transformations/models/open_cases/models.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:
+  - name: mpam_open_cases
+    columns:
+      - name: Case ID
+      - name: Business Area
+      - name: Age
+      - name: Deadline
+      - name: Stage

--- a/transformations/models/open_cases/mpam_open_cases.sql
+++ b/transformations/models/open_cases/mpam_open_cases.sql
@@ -1,0 +1,9 @@
+SELECT case_uuid AS "Case ID",
+       business_area AS "Business Area",
+       age AS "Age",
+       case_deadline AS "Deadline",
+       stage AS "Stage"
+
+FROM {{ ref('open_cases') }}
+
+WHERE case_type = 'MPAM'

--- a/transformations/models/open_cases/open_cases.sql
+++ b/transformations/models/open_cases/open_cases.sql
@@ -1,0 +1,14 @@
+WITH open_cases AS (
+    SELECT case_uuid,
+           business_area,
+           NOW()::date - date_created::date AS age,
+           case_deadline,
+           stage,
+           case_type
+
+    FROM {{ ref('merged_cases') }}
+
+    WHERE stage != 'CASE_CLOSED'
+)
+
+SELECT * FROM open_cases


### PR DESCRIPTION
Adding a view that should hopefully be able to be reused across different user groups. The only future work would be filtering on the different type. Unless the data is just wrong all together.

The MPAM open cases view should also be enough to create the majority of the graphs on that report with some minor pandas manipulation.